### PR TITLE
feat: dot env files when only development mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "BE for connecthon",
   "main": "index.js",
   "scripts": {
-    "dev": "ts-node-dev -r tsconfig-paths/register --watch ./src ./src/index.ts",
+    "dev": "cross-env NODE_ENV=development ts-node-dev -r tsconfig-paths/register --watch ./src ./src/index.ts",
     "prebuild": "rm -rf dist",
     "build": "tsc -p . && tsc-alias -p tsconfig.json",
-    "prod": "ts-node dist/index.js",
+    "start": "cross-env NODE_ENV=production node dist/src/index.js",
     "test": "jest --detectOpenHandles"
   },
   "repository": "https://github.com/DevKor-Team/connecthon-back.git",
@@ -17,6 +17,7 @@
     "argon2": "^0.28.5",
     "bson": "^4.6.4",
     "cookie-parser": "^1.4.6",
+    "cross-env": "^7.0.3",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "helmet": "^5.1.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,16 @@ import helmet from 'helmet';
 import http from 'http';
 import cookieParser from 'cookie-parser';
 import mongoose from 'mongoose';
-import 'dotenv/config';
+import dotenv from 'dotenv';
 import router from '@/routes';
+
+if (process.env.NODE_ENV === 'development') {
+  dotenv.config({
+    path: '.env',
+  });
+} else if (process.env.NODE_ENV === 'prouction') {
+  console.log('on production mode, set environment variables via other way');
+}
 
 // setup
 async function initialize() {
@@ -54,7 +62,8 @@ async function createServer() {
   // const io = new socketio.Server(server);
 
   // todo - different dev and prod settings
-  const port = 8080;
+  const port = process.env.PORT || 8080;
+
   httpServer.listen(port, () => {
     console.log(`server listening on port ${port}`); // todo - change console.log to logger
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1640,7 +1640,14 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-spawn@^7.0.2, cross-spawn@^7.0.3:
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
+cross-spawn@^7.0.1, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
* `yarn dev`로 실행할때만(development mode) .env 파일을 참조합니다. `yarn start`로 실행할때는(production mode) 별도로 환경 설정을 해줘야 합니다.
* 아직 aws 서버 등이 확정되지 않았으므로 docker compose 파일 등 빌드 관련 파일은 추후에 개발하겠습니다
* 현재는 간단하게 heroku를 개발 및 테스트용 서버로 활용하고 있습니다.
* user 기능을 테스트 하기 위해 feat/user에서 브랜치를 팠습니다. (feat/user로 pr 보내는 이유)